### PR TITLE
Support for creating an I2pAddr from a Base32-encoded destination

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -111,3 +111,12 @@ impl<I,E> From<nom::Err<I,E>> for Error {
 		}
 	}
 }
+
+impl From<data_encoding::DecodeError> for Error {
+  fn from(err: data_encoding::DecodeError) -> Error {
+    use std::error::Error;
+    self::Error {
+      inner: Context::new(ErrorKind::BadAddressEncoding(err.description().to_string())),
+    }
+  }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,41 +45,43 @@ pub enum ErrorKind {
 
 impl ErrorKind {
 	pub fn to_err(self) -> Error {
-		Error{inner: Context::new(self)}
+		Error {
+			inner: Context::new(self),
+		}
 	}
 }
 
 impl Display for Error {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let cause = match self.cause() {
-      Some(c) => format!("{}", c),
-      None => String::from("Unknown"),
-    };
-    let backtrace = match self.backtrace() {
-      Some(b) => format!("{}", b),
-      None => String::from("Unknown"),
-    };
-    let output = format!(
-      "{} \n Cause: {} \n Backtrace: {}",
-      self.inner, cause, backtrace
-    );
-    Display::fmt(&output, f)
-  }
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let cause = match self.cause() {
+			Some(c) => format!("{}", c),
+			None => String::from("Unknown"),
+		};
+		let backtrace = match self.backtrace() {
+			Some(b) => format!("{}", b),
+			None => String::from("Unknown"),
+		};
+		let output = format!(
+			"{} \n Cause: {} \n Backtrace: {}",
+			self.inner, cause, backtrace
+		);
+		Display::fmt(&output, f)
+	}
 }
 
 impl Error {
-  /// get kind
-  pub fn kind(&self) -> ErrorKind {
-    self.inner.get_context().clone()
-  }
-  /// get cause
-  pub fn cause(&self) -> Option<&dyn Fail> {
-    self.inner.cause()
-  }
-  /// get backtrace
-  pub fn backtrace(&self) -> Option<&Backtrace> {
-    self.inner.backtrace()
-  }
+	/// get kind
+	pub fn kind(&self) -> ErrorKind {
+		self.inner.get_context().clone()
+	}
+	/// get cause
+	pub fn cause(&self) -> Option<&dyn Fail> {
+		self.inner.cause()
+	}
+	/// get backtrace
+	pub fn backtrace(&self) -> Option<&Backtrace> {
+		self.inner.backtrace()
+	}
 }
 
 impl From<ErrorKind> for Error {
@@ -104,8 +106,8 @@ impl From<io::Error> for Error {
 	}
 }
 
-impl<I,E> From<nom::Err<I,E>> for Error {
-	fn from(_err: nom::Err<I,E>) -> Error {
+impl<I, E> From<nom::Err<I, E>> for Error {
+	fn from(_err: nom::Err<I, E>) -> Error {
 		Error {
 			inner: Context::new(ErrorKind::MessageParsing),
 		}
@@ -113,10 +115,10 @@ impl<I,E> From<nom::Err<I,E>> for Error {
 }
 
 impl From<data_encoding::DecodeError> for Error {
-  fn from(err: data_encoding::DecodeError) -> Error {
-    use std::error::Error;
-    self::Error {
-      inner: Context::new(ErrorKind::BadAddressEncoding(err.description().to_string())),
-    }
-  }
+	fn from(err: data_encoding::DecodeError) -> Error {
+		use std::error::Error;
+		self::Error {
+			inner: Context::new(ErrorKind::BadAddressEncoding(err.description().to_string())),
+		}
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@ pub mod sam;
 mod parsers;
 
 pub use crate::error::{Error, ErrorKind};
-pub use crate::sam::{Session, SamConnection};
+pub use crate::sam::{SamConnection, Session};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod error;
 pub mod net;
-mod sam;
+pub mod sam;
 
 mod parsers;
 

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -11,8 +11,8 @@ use crate::net::i2p::I2pAddr;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 pub struct I2pSocketAddr {
-	port: u16,
 	dest: I2pAddr,
+	port: u16,
 }
 
 impl I2pSocketAddr {
@@ -29,8 +29,8 @@ impl I2pSocketAddr {
 	/// ```
 	pub fn new(dest: I2pAddr, port: u16) -> I2pSocketAddr {
 		I2pSocketAddr {
-			port: port,
 			dest: dest,
+			port: port,
 		}
 	}
 

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -270,6 +270,18 @@ mod tests {
 		assert!(tsa("example.i2p:23924").unwrap().contains(&a));
 	}
 
+  #[test]
+  fn to_socket_addr_b32_str() {
+    let a = isa(I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p"), 24352);
+    assert_eq!(Ok(vec![a]), tsa("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p:24352"));
+
+    let b = I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p");
+    assert_eq!(b, I2pAddr::from_b32("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p").unwrap());
+
+    let a = isa(I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p"), 23924);
+    assert!(tsa("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p:23924").unwrap().contains(&a));
+  }
+
 	#[test]
 	fn to_socket_addr_string() {
 		let a = isa(I2pAddr::new("example.i2p"), 24352);

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -5,7 +5,7 @@ use std::option;
 use std::slice;
 use std::vec;
 
-use serde_derive::{Serialize, Deserialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::net::i2p::I2pAddr;
 
@@ -270,17 +270,34 @@ mod tests {
 		assert!(tsa("example.i2p:23924").unwrap().contains(&a));
 	}
 
-  #[test]
-  fn to_socket_addr_b32_str() {
-    let a = isa(I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p"), 24352);
-    assert_eq!(Ok(vec![a]), tsa("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p:24352"));
+	#[test]
+	fn to_socket_addr_b32_str() {
+		let a = isa(
+			I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p"),
+			24352,
+		);
+		assert_eq!(
+			Ok(vec![a]),
+			tsa("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p:24352")
+		);
 
-    let b = I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p");
-    assert_eq!(b, I2pAddr::from_b32("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p").unwrap());
+		let b = I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p");
+		assert_eq!(
+			b,
+			I2pAddr::from_b32("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p")
+				.unwrap()
+		);
 
-    let a = isa(I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p"), 23924);
-    assert!(tsa("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p:23924").unwrap().contains(&a));
-  }
+		let a = isa(
+			I2pAddr::new("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p"),
+			23924,
+		);
+		assert!(
+			tsa("cbuachhxwutpfpkejomn7xel2gdhf6n4fvhde4jog6tcmqbeztdq.b32.i2p:23924")
+				.unwrap()
+				.contains(&a)
+		);
+	}
 
 	#[test]
 	fn to_socket_addr_string() {

--- a/src/net/datagram.rs
+++ b/src/net/datagram.rs
@@ -61,7 +61,10 @@ impl I2pDatagramSocket {
 		super::each_i2p_addr(sam_addr, addr, I2pDatagramSocket::bind_addr).map_err(|e| e.into())
 	}
 
-	fn bind_addr(_sam_addr: &SocketAddr, _addr: &I2pSocketAddr) -> Result<I2pDatagramSocket, Error> {
+	fn bind_addr(
+		_sam_addr: &SocketAddr,
+		_addr: &I2pSocketAddr,
+	) -> Result<I2pDatagramSocket, Error> {
 		unimplemented!();
 	}
 

--- a/src/net/i2p.rs
+++ b/src/net/i2p.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
-use data_encoding::{BASE32, BASE32_NOPAD, Encoding, Specification};
+use data_encoding::{Encoding, Specification, BASE32, BASE32_NOPAD};
 use lazy_static::lazy_static;
 use log::error;
-use serde_derive::{Serialize, Deserialize};
-use sha2::{Sha256, Digest};
+use serde_derive::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::error::{Error, ErrorKind};
 
@@ -14,7 +14,8 @@ pub const B32_LEN: usize = 52usize;
 lazy_static! {
 	static ref BASE64_I2P: Encoding = {
 		let mut spec = Specification::new();
-		spec.symbols.push_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~");
+		spec.symbols
+			.push_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~");
 		spec.padding = Some('=');
 		spec.encoding().unwrap()
 	};
@@ -72,24 +73,29 @@ impl I2pAddr {
 		hasher.input(bin_data);
 		let mut b32 = BASE32.encode(&hasher.result());
 		b32.push_str(B32_EXT);
-		Ok(I2pAddr{inner: b32})
+		Ok(I2pAddr { inner: b32 })
 	}
 
-  /// Creates a new I2P address from a base32 encoded desthash string.
-  /// This checks proper encoding and expected lengths.
-  pub fn from_b32(addr: &str) -> Result<I2pAddr, Error> {
-     let b32_parts: Vec<&str> = addr.split(B32_EXT).collect();
-     if b32_parts.len() != 2 {
-       error!("Invalid Base32 encoded address: {:?}", addr);
-       return Err(ErrorKind::BadAddressEncoding(addr.to_string()).to_err());
-     }
-     if b32_parts[0].len() != B32_LEN {
-       error!("Invalid Base32 encoded length: {:?}, expected: {}", addr, B32_LEN);
-       return Err(ErrorKind::BadAddressEncoding(addr.to_string()).to_err());
-     }
-     BASE32_NOPAD.decode(b32_parts[0].to_uppercase().as_str().as_bytes())?;
-     Ok(I2pAddr{inner: addr.to_string()})
-  }
+	/// Creates a new I2P address from a base32 encoded desthash string.
+	/// This checks proper encoding and expected lengths.
+	pub fn from_b32(addr: &str) -> Result<I2pAddr, Error> {
+		let b32_parts: Vec<&str> = addr.split(B32_EXT).collect();
+		if b32_parts.len() != 2 {
+			error!("Invalid Base32 encoded address: {:?}", addr);
+			return Err(ErrorKind::BadAddressEncoding(addr.to_string()).to_err());
+		}
+		if b32_parts[0].len() != B32_LEN {
+			error!(
+				"Invalid Base32 encoded length: {:?}, expected: {}",
+				addr, B32_LEN
+			);
+			return Err(ErrorKind::BadAddressEncoding(addr.to_string()).to_err());
+		}
+		BASE32_NOPAD.decode(b32_parts[0].to_uppercase().as_str().as_bytes())?;
+		Ok(I2pAddr {
+			inner: addr.to_string(),
+		})
+	}
 
 	/// Returns the String that makes up this address.
 	///

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,5 @@
-use std::net::{SocketAddr, ToSocketAddrs};
 use crate::error::{Error, ErrorKind};
+use std::net::{SocketAddr, ToSocketAddrs};
 
 pub use self::addr::{I2pSocketAddr, ToI2pSocketAddrs};
 pub use self::datagram::I2pDatagramSocket;
@@ -33,10 +33,7 @@ where
 	Err(last_err.unwrap_or(ErrorKind::UnresolvableAddress.into()))
 }
 
-fn each_addr<A: ToSocketAddrs, F, T>(
-	sam_addr: A,
-	mut f: F,
-) -> Result<T, Error>
+fn each_addr<A: ToSocketAddrs, F, T>(sam_addr: A, mut f: F) -> Result<T, Error>
 where
 	F: FnMut(&SocketAddr) -> Result<T, Error>,
 {

--- a/src/net/streaming.rs
+++ b/src/net/streaming.rs
@@ -75,7 +75,9 @@ impl I2pStream {
 		session: &Session,
 		addr: A,
 	) -> Result<I2pStream, Error> {
-		let addr: Result<_, Error> = addr.to_socket_addrs()?.next()
+		let addr: Result<_, Error> = addr
+			.to_socket_addrs()?
+			.next()
 			.ok_or(ErrorKind::UnresolvableAddress.into());
 		I2pStream::connect_addr_with_session(session, &addr?)
 	}
@@ -93,7 +95,10 @@ impl I2pStream {
 		Ok(I2pStream { inner: stream })
 	}
 
-	fn connect_addr_with_session(session: &Session, addr: &I2pSocketAddr) -> Result<I2pStream, Error> {
+	fn connect_addr_with_session(
+		session: &Session,
+		addr: &I2pSocketAddr,
+	) -> Result<I2pStream, Error> {
 		let stream = StreamConnect::with_session(session, &addr.dest().string(), addr.port())?;
 
 		Ok(I2pStream { inner: stream })
@@ -270,7 +275,7 @@ impl I2pListener {
 
 	pub fn bind_with_session(session: &Session) -> Result<I2pListener, Error> {
 		let forward = StreamForward::with_session(session)?;
-		Ok(I2pListener{forward})
+		Ok(I2pListener { forward })
 	}
 
 	pub fn bind_via<A: ToSocketAddrs>(sam_addr: A) -> Result<I2pListener, Error> {
@@ -279,7 +284,7 @@ impl I2pListener {
 
 	fn bind_addr(sam_addr: &SocketAddr) -> Result<I2pListener, Error> {
 		let forward = StreamForward::new(sam_addr)?;
-		Ok(I2pListener{forward})
+		Ok(I2pListener { forward })
 	}
 
 	/// Returns the local socket address of this listener.
@@ -315,7 +320,7 @@ impl I2pListener {
 	/// ```
 	pub fn try_clone(&self) -> Result<I2pListener, Error> {
 		let forward = self.forward.duplicate()?;
-		Ok(I2pListener{forward})
+		Ok(I2pListener { forward })
 	}
 
 	/// Accept a new incoming connection from this listener.
@@ -337,7 +342,7 @@ impl I2pListener {
 	/// ```
 	pub fn accept(&self) -> Result<(I2pStream, I2pSocketAddr), Error> {
 		let (i2p_stream, addr) = self.forward.accept()?;
-		Ok((I2pStream{inner: i2p_stream}, addr))
+		Ok((I2pStream { inner: i2p_stream }, addr))
 	}
 
 	/// Returns an iterator over the connections being received on this

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,6 +1,4 @@
-use nom::{
-	alphanumeric, alt, do_parse, named, separated_list, space, tag_s, take_till_s,
-};
+use nom::{alphanumeric, alt, do_parse, named, separated_list, space, tag_s, take_till_s};
 
 fn is_space(chr: char) -> bool {
 	chr == ' ' || chr == '\t'
@@ -163,11 +161,15 @@ mod tests {
 		);
 
 		assert_eq!(
-			sam_naming_reply("NAMINGREPLY RESULT=KEY_NOT_FOUND\n").unwrap_err().into_error_kind(),
+			sam_naming_reply("NAMINGREPLY RESULT=KEY_NOT_FOUND\n")
+				.unwrap_err()
+				.into_error_kind(),
 			ErrorKind::Tag
 		);
 		assert_eq!(
-			sam_naming_reply("NAMING  REPLY RESULT=KEY_NOT_FOUND\n").unwrap_err().into_error_kind(),
+			sam_naming_reply("NAMING  REPLY RESULT=KEY_NOT_FOUND\n")
+				.unwrap_err()
+				.into_error_kind(),
 			ErrorKind::Tag
 		);
 	}

--- a/src/sam.rs
+++ b/src/sam.rs
@@ -10,10 +10,11 @@ use nom::IResult;
 use rand::distributions::Alphanumeric;
 use rand::{self, Rng};
 
-
 use crate::error::{Error, ErrorKind};
 use crate::net::{I2pAddr, I2pSocketAddr};
-use crate::parsers::{sam_hello, sam_naming_reply, sam_session_status, sam_stream_status, sam_dest_reply};
+use crate::parsers::{
+	sam_dest_reply, sam_hello, sam_naming_reply, sam_session_status, sam_stream_status,
+};
 
 pub static DEFAULT_API: &'static str = "127.0.0.1:7656";
 
@@ -130,7 +131,10 @@ impl SamConnection {
 	}
 
 	pub fn duplicate(&self) -> Result<SamConnection, Error> {
-		self.conn.try_clone().map(|s| SamConnection { conn: s }).map_err(|e| e.into())
+		self.conn
+			.try_clone()
+			.map(|s| SamConnection { conn: s })
+			.map_err(|e| e.into())
 	}
 }
 
@@ -163,7 +167,10 @@ impl Session {
 
 	/// Create a new session identified by the provided destination. Auto-generates
 	/// a nickname uniquely associated with the new session.
-	pub fn from_destination<A: ToSocketAddrs>(sam_addr: A, destination: &str) -> Result<Session, Error> {
+	pub fn from_destination<A: ToSocketAddrs>(
+		sam_addr: A,
+		destination: &str,
+	) -> Result<Session, Error> {
 		Self::create(sam_addr, destination, &nickname(), SessionStyle::Stream)
 	}
 
@@ -182,16 +189,18 @@ impl Session {
 	}
 
 	pub fn duplicate(&self) -> Result<Session, Error> {
-		self.sam.duplicate().map(|s| Session {
-			sam: s,
-			local_dest: self.local_dest.clone(),
-			nickname: self.nickname.clone(),
-		}).map_err(|e| e.into())
+		self.sam
+			.duplicate()
+			.map(|s| Session {
+				sam: s,
+				local_dest: self.local_dest.clone(),
+				nickname: self.nickname.clone(),
+			})
+			.map_err(|e| e.into())
 	}
 }
 
 impl StreamConnect {
-
 	/// Create a new SAM client connection to the provided destination and port.
 	/// Also creates a new transient session to support the connection.
 	pub fn new<A: ToSocketAddrs>(
@@ -278,16 +287,18 @@ pub struct StreamForward {
 }
 
 impl StreamForward {
-	pub fn new<A: ToSocketAddrs>(
-		sam_addr: A,
-	) -> Result<StreamForward, Error> {
-		Ok(StreamForward {session: Session::transient(sam_addr)?})
+	pub fn new<A: ToSocketAddrs>(sam_addr: A) -> Result<StreamForward, Error> {
+		Ok(StreamForward {
+			session: Session::transient(sam_addr)?,
+		})
 	}
 
 	/// Create a new SAM client connection to the provided destination and port
 	/// using the provided session.
 	pub fn with_session(session: &Session) -> Result<StreamForward, Error> {
-		Ok(StreamForward {session: session.duplicate()?})
+		Ok(StreamForward {
+			session: session.duplicate()?,
+		})
 	}
 
 	pub fn accept(&self) -> Result<(StreamConnect, I2pSocketAddr), Error> {
@@ -316,12 +327,14 @@ impl StreamForward {
 			dest_line.split(" ").next().unwrap_or("").trim().to_string()
 		};
 		if destination.is_empty() {
-			return Err(ErrorKind::SAMKeyNotFound("No b64 destination in accept".to_string()).into());
+			return Err(
+				ErrorKind::SAMKeyNotFound("No b64 destination in accept".to_string()).into(),
+			);
 		}
 
 		let addr = I2pSocketAddr::new(I2pAddr::from_b64(&destination)?, 0);
 		stream.peer_dest = destination;
-	
+
 		Ok((stream, addr))
 	}
 
@@ -330,7 +343,9 @@ impl StreamForward {
 	}
 
 	pub fn duplicate(&self) -> Result<StreamForward, Error> {
-		Ok(StreamForward {session: self.session.duplicate()?})
+		Ok(StreamForward {
+			session: self.session.duplicate()?,
+		})
 	}
 }
 


### PR DESCRIPTION
Adds support for decoding an I2pAddr from a Base32-encoded destination.

Also includes minor formatting, and style fix-ups.